### PR TITLE
Fixing and simplifying final config creation

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -56,7 +56,7 @@ jobs:
         echo "::set-output name=BEFORE::$(git status --porcelain -b)"
 
     - name: Tests
-      run: pytest tests -v --disable-pytest-warnings
+      run: python -m pytest tests -v --disable-pytest-warnings
 
     - name: Check for files left behind by test
       run: |

--- a/hydra_plugins/hypersweeper/hypersweeper_backend.py
+++ b/hydra_plugins/hypersweeper/hypersweeper_backend.py
@@ -3,13 +3,11 @@
 from __future__ import annotations
 
 import logging
-import operator
 from collections.abc import Callable
-from functools import reduce
 from pathlib import Path
 from typing import TYPE_CHECKING
-import numpy as np
 
+import numpy as np
 from hydra.core.plugins import Plugins
 from hydra.plugins.sweeper import Sweeper
 from hydra.utils import get_class, get_method
@@ -166,8 +164,8 @@ class HypersweeperBackend(Sweeper):
             del final_config["hydra"]
 
         for k, v in incumbent.items():
-            if isinstance(v, (np.integer, np.floating)):
-                v = v.item()
+            if isinstance(v, np.integer | np.floating):
+                v = v.item()  # noqa: PLW2901
             OmegaConf.update(final_config, k, v, force_add=True)
 
         with open(Path(optimizer.output_dir) / "final_config.yaml", "w+") as fp:

--- a/hydra_plugins/hypersweeper/hypersweeper_sweeper.py
+++ b/hydra_plugins/hypersweeper/hypersweeper_sweeper.py
@@ -523,4 +523,4 @@ class HypersweeperSweeper:
                     incumbent had a performance of {np.round(inc_performance, decimals=2)}"
             )
             log.info(f"The incumbent configuration is {inc_config}")
-        return self.incumbents[-1]
+        return self.incumbents["config"][-1]


### PR DESCRIPTION
There is a bug in the final config creation. The line https://github.com/automl/hypersweeper/blob/5b53d9d6b39d6cd00ac8b3f71503d7cbf8c74ba0/hydra_plugins/hypersweeper/hypersweeper_sweeper.py#L526 always returns an empty list since the key `-1` is not defined. It should be `self.incumbents["config"][-1]`.

I fixed this and simplified the final config creation with an additional resolution to make the final configs usable for evaluation experiments out of the box.